### PR TITLE
Small README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Maven Central Version](https://img.shields.io/maven-central/v/com.github.nradov/abnffuzzer)](https://central.sonatype.com/artifact/com.github.nradov/abnffuzzer)
+[![Javadoc](https://img.shields.io/badge/javadoc-brightgreen.svg)](https://nradov.github.io/abnffuzzer/site-plugin/apidocs/index.html)
+
 # ABNF Fuzzer
 This is a Java [fuzz testing](https://en.wikipedia.org/wiki/Fuzz_testing) tool that can find defects in implementations of Augmented Backus-Naur Form (ABNF) rules such as IETF RFCs. ABNF is itself defined in RFCs [5234](https://tools.ietf.org/html/rfc5234) and [7405](https://tools.ietf.org/html/rfc7405). You can use it to generate random valid inputs for test cases, which can be helpful for finding edge case defects. I wrote it primarily as a way to learn [ANTLR](https://www.antlr.org/). Thanks to @rainerschuster for providing the [Anbf.g4](https://github.com/antlr/grammars-v4/blob/master/abnf/Abnf.g4) grammar.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ABNF Fuzzer
-This is a Java [fuzz testing](https://en.wikipedia.org/wiki/Fuzz_testing) tool that can find defects in implementations of Augmented Backus-Naur Form (ABNF) rules such as IETF RFCs. ABNF is itself defined in RFCs [5234](https://tools.ietf.org/html/rfc5234) and [7405](https://tools.ietf.org/html/rfc7405). You can use it to generate random valid inputs for test cases, which can be helpful for finding edge case defects. I wrote it primarily as a way to learn [ANTLR](http://www.antlr.org/). Thanks to @rainerschuster for providing the [Anbf.g4](https://github.com/antlr/grammars-v4/blob/master/abnf/Abnf.g4) grammar.
+This is a Java [fuzz testing](https://en.wikipedia.org/wiki/Fuzz_testing) tool that can find defects in implementations of Augmented Backus-Naur Form (ABNF) rules such as IETF RFCs. ABNF is itself defined in RFCs [5234](https://tools.ietf.org/html/rfc5234) and [7405](https://tools.ietf.org/html/rfc7405). You can use it to generate random valid inputs for test cases, which can be helpful for finding edge case defects. I wrote it primarily as a way to learn [ANTLR](https://www.antlr.org/). Thanks to @rainerschuster for providing the [Anbf.g4](https://github.com/antlr/grammars-v4/blob/master/abnf/Abnf.g4) grammar.
 
-For additional documentation including dependency information and Javadoc please see the [Maven generated site](http://nradov.github.io/abnffuzzer/site-plugin/).
+For additional documentation including dependency information please see the [Maven generated site](https://nradov.github.io/abnffuzzer/site-plugin/) and the [Javadoc](https://nradov.github.io/abnffuzzer/site-plugin/apidocs/index.html).
 
 ## Usage
-This tool can be called directly from Java code — such as a [JUnit](http://junit.org/) test case — or from the command line. In order to use it you first need a file containing **only** ABNF rule definitions. Here's a sample simple ABNF rules file.
+This tool can be called directly from Java code — such as a [JUnit](https://junit.org/) test case — or from the command line. In order to use it you first need a file containing **only** ABNF rule definitions. Here's a sample simple ABNF rules file.
 
-```
+```abnf
 foo = bar / baz
 bar = "Hello"
 baz = "World!"
@@ -24,22 +24,22 @@ With some complex ABNF files the fuzzer may cause the JVM to run out of memory o
 Call one of the `generate` methods wherever you need a random `String` or `byte[]` value matching a particular ABNF rule. For example let's say you have a class named `MyClass` containing a method named `myMethod` which takes a `String` parameter and returns `true` if that parameter matches ABNF rule "foo" defined in RFC 99999. 
 
 ```java
-    @Test
-    public void testMyMethod() throws IOException {
-        File file = new File("rfc99999.txt");
-        Fuzzer fuzzer = new Fuzzer(file);
-        
-        MyClass m = new MyClass();
-        for (int i = 0; i < 100; i++) {
-            assertTrue(m.myMethod(fuzzer.generateAscii("foo")));
-        }
+@Test
+public void testMyMethod() throws IOException {
+    File file = new File("rfc99999.txt");
+    Fuzzer fuzzer = new Fuzzer(file);
+
+    MyClass m = new MyClass();
+    for (int i = 0; i < 100; i++) {
+        assertTrue(m.myMethod(fuzzer.generateAscii("foo")));
     }
+}
 ```
 
-For additional samples see the [JUnit test cases](https://github.com/nradov/abnffuzzer/tree/master/src/test/java/com/github/nradov/abnffuzzer) in this repository.
+For additional samples see the [JUnit test cases](./src/test/java/com/github/nradov/abnffuzzer) in this repository.
 
 ### Command Line
-For testing web services or applications written in other languages this tool can also be called from the command line. Binary jar file releases are available through this repository. By default it reads ABNF rules from `stdin`, generates a random value matching the ABNF rule named as the last command-line parameter, and writes it to `stdout`. You need to have the ANTLR [Java runtime binaries](http://www.antlr.org/download.html) and Apache [Commons CLI](https://commons.apache.org/proper/commons-cli/) in your `CLASSPATH`. Command-line options are available to control the number of values to generate, character set, input source, ouput destination. Use the `-?` command-line option for help on those options.
+For testing web services or applications written in other languages this tool can also be called from the command line. Binary jar file releases are available through this repository. By default it reads ABNF rules from `stdin`, generates a random value matching the ABNF rule named as the last command-line parameter, and writes it to `stdout`. You need to have the ANTLR [Java runtime binaries](https://www.antlr.org/download.html) and Apache [Commons CLI](https://commons.apache.org/proper/commons-cli/) in your `CLASSPATH`. Command-line options are available to control the number of values to generate, character set, input source, ouput destination. Use the `-?` command-line option for help on those options.
 
 ```
 java com.github.nradov.abnffuzzer.Fuzzer -n 1000 -i rfc99999.txt -o testcases.txt foo


### PR DESCRIPTION
Hello,
I tried to improve the README a bit:
- Added badges for Maven Central artifact and Javadoc, so that users can find it more easily\
The Maven Central badge is especially useful because users can easily obtain the dependency coordinates for their build tool there.
- Added direct link to Javadoc because it is a bit difficult to find on the Maven generated page
- Replaced `http://` with `https://` URLs

Please let me know if you want anything changed, or you don't think these changes are necessary. Or feel free to adjust this pull request as you like.